### PR TITLE
Tests Do Not Fail

### DIFF
--- a/src/JasmineAdapter.js
+++ b/src/JasmineAdapter.js
@@ -55,8 +55,9 @@ jasmine.Env.prototype.it = function(description, closure){
 		frame.runBefore.apply(currentSpec);
 		try {
 			currentSpec.queue.start();
-		} catch(e){}
-		frame.runAfter.apply(currentSpec);
+		} finally {
+		  frame.runAfter.apply(currentSpec);
+		}
 	};
 	return result;
 };

--- a/test.sh
+++ b/test.sh
@@ -8,12 +8,12 @@ do
   fi
 done
 
-if [ -e $JSTD ]; then
+if [ -z "$JSTD" ]; then
 	#statements
-	JSTD=`ls ../jstestdriver/[jJ]s[tT]est[dD]river*.jar`
+	JSTD="./lib/JsTestDriver.jar"
 fi
 
-if [ -e $TESTS ]; then
+if [ -z "$TESTS" ]; then
   TESTS="all"
   echo "Running all tests"
 else

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ done
 
 if [ -z "$JSTD" ]; then
 	#statements
-	JSTD="./lib/JsTestDriver.jar"
+	JSTD=`ls ../jstestdriver/[jJ]s[tT]est[dD]river*.jar`
 fi
 
 if [ -z "$TESTS" ]; then

--- a/test.sh
+++ b/test.sh
@@ -20,4 +20,4 @@ else
   echo "Running '$TESTS'"
 fi
 
-java -jar $JSTD --reset --tests $TESTS
+java -jar $JSTD --reset --tests "$TESTS"

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,23 @@
-if [ $# -eq 1 ]; then
-	JSTD=$1
-fi
+#!/bin/bash
+while getopts  "j:t:" flag
+do
+  if [ $flag == "j" ]; then
+    JSTD=$OPTARG
+  elif [ $flag == "t" ]; then
+    TESTS=$OPTARG
+  fi
+done
 
 if [ -e $JSTD ]; then
 	#statements
 	JSTD=`ls ../jstestdriver/[jJ]s[tT]est[dD]river*.jar`
 fi
 
-java -jar $JSTD --tests all --reset
+if [ -e $TESTS ]; then
+  TESTS="all"
+  echo "Running all tests"
+else
+  echo "Running '$TESTS'"
+fi
+
+java -jar $JSTD --reset --tests $TESTS


### PR DESCRIPTION
I fixed an issue with tests not failing properly.  They would appear as passed because the errors were getting caught and ignored by the adapter, not by JsTestDriver itself.  I also updated the test.sh file to take -j and/or -t options.

Usage
-j "path to .jar file"
-t "test(s) to run"

This allows you to specify specific tests or describe blocks to run.
