### PR TITLE
Fix to work with latest version of jstd

### DIFF
--- a/src/JasmineAdapter.js
+++ b/src/JasmineAdapter.js
@@ -109,7 +109,6 @@ beforeEach = intercept('beforeEach');
 afterEach = intercept('afterEach');
 
 var JASMINE_TYPE = 'jasmine test case';
-TestCase('Jasmine Adapter Tests', null, JASMINE_TYPE);
 
 jstestdriver.pluginRegistrar.register({
 
@@ -124,8 +123,16 @@ jstestdriver.pluginRegistrar.register({
 	onTestsFinish: function(){
 		jasmine.currentEnv_ = null;
 		collectMode = true;
-	}
+	},
 
+  getTestRunsConfigurationFor: function(testCaseInfos, expressions, testRunsConfiguration){
+    testRunsConfiguration.push(
+        new jstestdriver.TestRunConfiguration(
+            new jstestdriver.TestCaseInfo(
+                'Jasmine Adapter Tests', function() {}, JASMINE_TYPE), []));
+
+    return true;
+  }
 });
 
 function intercept(method){


### PR DESCRIPTION
There is new feature - running only tests that matches given regular expression.
See this change log: http://code.google.com/p/js-test-driver/source/detail?r=952

I haven't tested this change with jasmine adapter, you can build latest jstd (get trunk from svn) and test it.
This should work with current version as well.

I have tested that only with our angular scenario runner adapter which uses complete the same way of reporting results to jstd and it works fine with current version of jstd as well as new version (not released yet).
