### PR TITLE
Syntax error that prevented the JasmineAdapter.js file from being loaded 

### DIFF
--- a/src/JasmineAdapter.js
+++ b/src/JasmineAdapter.js
@@ -118,7 +118,7 @@ jstestdriver.pluginRegistrar.register({
 	getTestRunsConfigurationFor: function(testCaseInfos, expressions, testRunsConfiguration) {
         	for (var i = 0; i < testCaseInfos.length; i++) {
                 	if (testCaseInfos[i].getType() == JASMINE_TYPE) {
-				testRunsConfiguration.push(new jstestdriver.TestRunConfiguration(testCaseInfos[i], []);
+				testRunsConfiguration.push(new jstestdriver.TestRunConfiguration(testCaseInfos[i], []));
 			}
 		}
 		return false; // allow other TestCases to be collected.


### PR DESCRIPTION
Syntax error that prevented the JasmineAdapter.js file from being loaded when running tests
